### PR TITLE
Add trackerRecoGeometry to PixelTelescopeRecoGeometry_cfi.py, so that…

### DIFF
--- a/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.cc
+++ b/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.cc
@@ -45,7 +45,7 @@ GlobalTrackingGeometryESProducer::produce(const GlobalTrackingGeometryRecord& re
     LogWarning("GeometryGlobalTrackingGeometryBuilder") << "No TrackerDigiGeometryRecord is available.";    
   }
 
-
+  /*
   try {
     edm::ESHandle<DTGeometry> dtH;
     record.getRecord<MuonGeometryRecord>().get(dtH);
@@ -90,6 +90,7 @@ GlobalTrackingGeometryESProducer::produce(const GlobalTrackingGeometryRecord& re
   } catch (edm::eventsetup::NoRecordException<MuonGeometryRecord>& e){
     LogWarning("GeometryGlobalTrackingGeometryBuilder") << "No MuonGeometryRecord is available.";    
   }
+  */
 
   GlobalTrackingGeometryBuilder builder;
   return std::shared_ptr<GlobalTrackingGeometry>(builder.build(tk, dt, csc, rpc, gem, me0));

--- a/Geometry/GlobalTrackingGeometryBuilder/test/testGlobalTrackingGeometry_cfg.py
+++ b/Geometry/GlobalTrackingGeometryBuilder/test/testGlobalTrackingGeometry_cfg.py
@@ -1,14 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Demo")
-process.load('Configuration.Geometry.GeometryExtended2019_cff')
-process.load('Configuration.Geometry.GeometryExtended2019Reco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2019_cff')
+process.load('Geometry.PixelTelescope.PixelTelescopeRecoGeometry_cfi')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2019', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2017_realistic', '')
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/Geometry/PixelTelescope/python/PixelTelescopeRecoGeometry_cfi.py
+++ b/Geometry/PixelTelescope/python/PixelTelescopeRecoGeometry_cfi.py
@@ -7,6 +7,8 @@ trackerNumberingGeometry = cms.ESProducer('TrackerGeometricDetESModule',
   appendToDataLabel = cms.string('')
 )
 
+from Geometry.CommonDetUnit.globalTrackingGeometry_cfi import *
+
 trackerGeometry = cms.ESProducer('TrackerDigiGeometryESModule',
   appendToDataLabel = cms.string(''),
   fromDDD = cms.bool(True),
@@ -17,3 +19,11 @@ trackerGeometry = cms.ESProducer('TrackerDigiGeometryESModule',
 trackerTopology = cms.ESProducer('TrackerTopologyEP',
   appendToDataLabel = cms.string('')
 )
+
+trackerRecoGeometry = cms.ESProducer("TrackerRecoGeometryESProducer",
+    appendToDataLabel = cms.string(''),
+    trackerGeometryLabel = cms.untracked.string('')
+)
+#hltESPTrackerRecoGeometryESProducer
+#from RecoTracker.GeometryESProducer.TrackerRecoGeometryESProducer_cfi import *
+

--- a/Geometry/PixelTelescope/test/tracking_v2.py
+++ b/Geometry/PixelTelescope/test/tracking_v2.py
@@ -14,7 +14,7 @@ opt.register('inputDir',  '/afs/cern.ch/work/m/mersi/public/Chromie/RAW/run10020
 	     opts.VarParsing.multiplicity.singleton, opts.VarParsing.varType.string,
 	     'Directory of input raw files')
 
-opt.register('outputFileName', 'PixelTelescope_BeamData_OUTPUT.root',
+opt.register('outputFileName', 'PixelTelescope_BeamData_OUTPUT_RECO.root',
 	     opts.VarParsing.multiplicity.singleton, opts.VarParsing.varType.string,
 	     'Name of output reco file')
 
@@ -169,12 +169,9 @@ process.DQMData = cms.EDAnalyzer('Ana3D',
 process.DQM = cms.Path(process.DQMData)
 
 
-
-############## Track reconstruction ##############
-############## Track reconstruction ##############
-############## Track reconstruction ##############
-############## Track reconstruction ##############
-############## Track reconstruction ##############
+###########################################################################################
+############################### Track reconstruction ######################################
+###########################################################################################
 
 
 # Tracking configuration file fragment for P5 cosmic running
@@ -182,13 +179,10 @@ process.DQM = cms.Path(process.DQMData)
 
 
 #process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+#process.load("RecoTracker.Configuration.RecoTrackerP5_cff")
 #process.load('Geometry.PixelTelescope.PixelTelescopeDBConditions_cfi')
 #process.load('Geometry.PixelTelescope.PixelTelescopeRecoGeometry_cfi')
-#process.load("RecoTracker.Configuration.RecoTrackerP5_cff")
-process.hltESPTrackerRecoGeometryESProducer = cms.ESProducer("TrackerRecoGeometryESProducer",
-    appendToDataLabel = cms.string(''),
-    trackerGeometryLabel = cms.untracked.string('')
-)
+
 
 #process.load('RecoTracker.TkNavigation.CosmicsNavigationSchoolESProducer_cfi')
 process.load('RecoTracker.TkNavigation.TelescopeNavigationSchoolESProducer_cfi')
@@ -229,8 +223,7 @@ process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi")
 process.load("RecoTracker.MeasurementDet.MeasurementTrackerESProducer_cfi")
 
 process.ctfWithMaterialTracksCosmics.NavigationSchool = cms.string("TelescopeNavigationSchool")
-# process.ctfWithMaterialTracksCosmics.beamSpot = cms.InputTag("")
-
+#process.ctfWithMaterialTracksCosmics.beamSpot = cms.InputTag("")   NB: Beam spot is not valid, NEED TO FIX THIS. See https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFindingBeamSpot
 
 # Final Track Selector for CTF
 #from RecoTracker.FinalTrackSelectors.CTFFinalTrackSelectorP5_cff import *
@@ -300,18 +293,17 @@ process.RKTrajectoryFitter = cms.ESProducer("KFTrajectoryFitterESProducer",
 )
 
 
-#HEREEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
-#process.ctftracksP5 = cms.Sequence(process.combinatorialcosmicseedingtripletsP5+process.combinatorialcosmicseedfinderP5*process.MeasurementTrackerEvent*
-#			    process.ckfTrackCandidatesP5*process.ctfWithMaterialTracksCosmics*process.ctfWithMaterialTracksP5)
-# HEREEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE
+###################################################################################################################
+# DEFINE SEQUENCE
 
 #process.ctftracksP5 = cms.Sequence(process.combinatorialcosmicseedinglayersP5)
 
 process.ctftracksP5 = cms.Sequence(process.combinatorialcosmicseedingtripletsP5+process.combinatorialcosmicseedfinderP5*process.MeasurementTrackerEvent*
 			    process.ckfTrackCandidatesP5*process.ctfWithMaterialTracksCosmics)
 			    
-			    
-
+#process.ctftracksP5 = cms.Sequence(process.combinatorialcosmicseedingtripletsP5+process.combinatorialcosmicseedfinderP5*process.MeasurementTrackerEvent*
+#			    process.ckfTrackCandidatesP5*process.ctfWithMaterialTracksCosmics*process.ctfWithMaterialTracksP5)			    
+###################################################################################################################
 
 
 


### PR DESCRIPTION
… it can be included in any test. + Add trackingGeometry, based on telescope geometry only (seen as a tracker). DT, muon chambers and so on are desactivated, which cannot harm.